### PR TITLE
Update get-args.zig to add the missing newline

### DIFF
--- a/source/processed/samples/get-args.zig
+++ b/source/processed/samples/get-args.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 
 const alloc = std.testing.allocator;
 
-// Sample starts here{{ slot contents }}\
+// Sample starts here{{ slot contents }}
 test "argsWithAllocator - get an iterator, use an allocator" {
     var args = try std.process.argsWithAllocator(alloc);
     defer args.deinit();


### PR DESCRIPTION
The tailing `\` causes the next line to be on the same line. Behaviour Observed while downloading `https://renatoathaydes.github.io/zig-common-tasks/samples/get-args.zig`

BTW, thx for the awesome resource.