### PR TITLE
Added Added json parse using std.json.Value

### DIFF
--- a/source/processed/samples/parse-json.zig
+++ b/source/processed/samples/parse-json.zig
@@ -13,7 +13,7 @@ test "Parse JSON object" {
     ;
     const JsonStruct = struct {
         a_number: u32,
-        a_str: []const u8
+        a_str: []const u8,
     };
 
     const parsed = try std.json.parseFromSlice(JsonStruct, alloc, example_json, .{});
@@ -22,4 +22,51 @@ test "Parse JSON object" {
     const result = parsed.value;
     try std.testing.expectEqual(@as(u32, 10), result.a_number);
     try std.testing.expectEqualSlices(u8, "hello", result.a_str);
+}
+
+test "Parse a complex JSON object" {
+    const example_json: []const u8 =
+        \\{
+        \\  "a_number": 10,
+        \\  "a_str": "hello",
+        \\  "a_float": 3.14,
+        \\  "a_bool": true,
+        \\  "a_null": null,
+        \\  "a_number_array": [1, 2, 3],
+        \\  "a_string_array": ["one", "two", "three"],
+        \\  "nested": { "key": "value" }
+        \\}
+    ;
+
+    const parsed: std.json.Parsed(std.json.Value) = try std.json.parseFromSlice(std.json.Value, alloc, example_json, .{});
+    defer parsed.deinit();
+
+    const result = parsed.value.object; // This is the root of the JSON structure, and it is a map of all the keys of the JSON.
+
+    try std.testing.expectEqual(10, result.get("a_number").?.integer);
+
+    try std.testing.expectEqualSlices(u8, "hello", result.get("a_str").?.string);
+
+    try std.testing.expectEqual(3.14, result.get("a_float").?.float);
+
+    try std.testing.expectEqual(true, result.get("a_bool").?.bool);
+
+    try std.testing.expectEqual(.null, result.get("a_null").?);
+
+    const number_array = result.get("a_number_array").?.array;
+    const expected_array = [_]i32{ 1, 2, 3 };
+    try std.testing.expectEqual(expected_array.len, number_array.items.len);
+    for (0..expected_array.len) |i| {
+        try std.testing.expectEqual(expected_array[i], number_array.items[i].integer);
+    }
+
+    const json_string_array = result.get("a_string_array").?.array;
+    const expected_str_array = [_][]const u8{ "one", "two", "three" };
+    try std.testing.expectEqual(expected_str_array.len, json_string_array.items.len);
+    for (0..expected_str_array.len) |i| {
+        try std.testing.expectEqualStrings(expected_str_array[i], json_string_array.items[i].string);
+    }
+
+    const nested = result.get("nested").?.object;
+    try std.testing.expectEqualStrings("value", nested.get("key").?.string);
 }

--- a/source/processed/samples/parse-json.zig
+++ b/source/processed/samples/parse-json.zig
@@ -43,18 +43,18 @@ test "Parse a complex JSON object" {
 
     const result = parsed.value.object; // This is the root of the JSON structure, and it is a map of all the keys of the JSON.
 
-    try std.testing.expectEqual(10, result.get("a_number").?.integer);
+    try std.testing.expectEqual(@as(i64, 10), result.get("a_number").?.integer);
 
     try std.testing.expectEqualSlices(u8, "hello", result.get("a_str").?.string);
 
-    try std.testing.expectEqual(3.14, result.get("a_float").?.float);
+    try std.testing.expectEqual(@as(f64, 3.14), result.get("a_float").?.float);
 
     try std.testing.expectEqual(true, result.get("a_bool").?.bool);
 
     try std.testing.expectEqual(.null, result.get("a_null").?);
 
     const number_array = result.get("a_number_array").?.array;
-    const expected_array = [_]i32{ 1, 2, 3 };
+    const expected_array = [_]i64{ 1, 2, 3 };
     try std.testing.expectEqual(expected_array.len, number_array.items.len);
     for (0..expected_array.len) |i| {
         try std.testing.expectEqual(expected_array[i], number_array.items[i].integer);


### PR DESCRIPTION
This pull request adds a comprehensive test for parsing complex JSON objects, expanding the coverage of the JSON parsing functionality. The new test ensures that various JSON data types—including numbers, strings, floats, booleans, nulls, arrays, and nested objects—are correctly parsed and validated.

**Added test coverage for complex JSON parsing:**

* Added a new test, `Parse a complex JSON object`, to verify parsing of multiple data types (numbers, strings, floats, booleans, nulls, arrays, and nested objects) from a JSON object using `std.json.parseFromSlice`. It also lets you avoid building a complex structure when there are too many JSON keys.

**Minor code style improvement:**

* Added a trailing comma to the `JsonStruct` definition for consistency.